### PR TITLE
Add an explanation for auto saving based on specific languages/file types

### DIFF
--- a/docs/editor/codebasics.md
+++ b/docs/editor/codebasics.md
@@ -95,6 +95,13 @@ For more control over `Auto Save`, open User or Workspace [settings](/docs/getst
   * `onWindowChange` - to save files when the focus moves out of the VS Code window.
 * `setting(files.autoSaveDelay)`: Configures the delay in milliseconds when `setting(files.autoSave)` is configured to `afterDelay`. The default is 1000 ms.
 
+If you want to customize `Auto Save` features for specific languages or file types, you can do so from your `setting.json` by adding language specific rules. For example, you could disable `Auto Save` for LaTeX files like this:
+```json
+    "[latex]": {
+        "files.autoSave": "off",
+    },
+```
+
 ## Hot Exit
 
 By default, VS Code remembers unsaved changes to files when you exit. Hot exit is triggered when the application is closed via **File** > **Exit** (**Code** > **Quit** on macOS) or when the last window is closed.


### PR DESCRIPTION
I added a short explanation of how to customize the auto save feature for specific language types, since the feature is currently not mentioned in the documentation or in the Settings GUI.